### PR TITLE
bresenham impl merge with main renderer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -99,9 +99,9 @@ fn main() {
             let mid_width_canvas = (render.framebuffer.width/2) as i32;
             let mid_height_canvas = (render.framebuffer.height/2) as i32;
             render.draw_triangle(
-                mid_width_canvas, mid_height_canvas-25,
-                mid_width_canvas-25, mid_height_canvas+25,
-                mid_width_canvas+25, mid_height_canvas+25, false, 3, draw_color);
+                mid_width_canvas, mid_height_canvas-50,
+                mid_width_canvas-50, mid_height_canvas+50,
+                mid_width_canvas+50, mid_height_canvas+50, false, 20, draw_color);
                 count_but+=1;
         }
         

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,9 +55,9 @@ fn main() {
             //    count_but+=1;
         }
         if window.is_key_pressed(Key::Right, KeyRepeat::No){
-            //let mid_canvas = (render.framebuffer.height/2) as i32;
-              //  render.draw_horizontal_line(0, mid_canvas, render.framebuffer.width as i32, 3, draw_color);
-                //count_but+=1;
+            let mid_canvas = render.framebuffer.height/2;
+            render.draw_horizontal_line(0, mid_canvas, render.framebuffer.width, mid_canvas, 3, draw_color);
+            count_but+=1;
         }
         if window.is_key_pressed(Key::Left, KeyRepeat::No){
                 //render.draw_perfect_diagonal_line(0, 0, render.framebuffer.width as i32, render.framebuffer.height as i32, 3, draw_color);

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,13 +78,13 @@ fn main() {
         if window.is_key_pressed(Key::S, KeyRepeat::No){
             let mid_width_canvas = (render.framebuffer.width/2) as i32;
             let mid_height_canvas = (render.framebuffer.height/2) as i32;
-            /*render.draw_rectangle_unfilled(
+            render.draw_rectangle_unfilled(
                 mid_width_canvas, 
                 mid_height_canvas, 
                 55, 
                 55, 
                 3, 
-                draw_color);*/
+                draw_color);
                 count_but+=1;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,9 +50,9 @@ fn main() {
             count_but+=1;
         }
         if window.is_key_pressed(Key::Up, KeyRepeat::No){
-            //let mid_canvas = (render.framebuffer.width/2) as i32;    
-            //    render.draw_vertical_line(mid_canvas, 0, render.framebuffer.height as i32, 3, draw_color);
-            //    count_but+=1;
+            let mid_canvas = render.framebuffer.width/2;    
+                render.draw_vertical_line(mid_canvas, 0, mid_canvas, render.framebuffer.height, 3, draw_color);
+                count_but+=1;
         }
         if window.is_key_pressed(Key::Right, KeyRepeat::No){
             let mid_canvas = render.framebuffer.height/2;

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,22 +50,22 @@ fn main() {
             count_but+=1;
         }
         if window.is_key_pressed(Key::Up, KeyRepeat::No){
-            let mid_canvas = (render.framebuffer.width/2) as i32;    
-                render.draw_vertical_line(mid_canvas, 0, render.framebuffer.height as i32, 3, draw_color);
-                count_but+=1;
+            //let mid_canvas = (render.framebuffer.width/2) as i32;    
+            //    render.draw_vertical_line(mid_canvas, 0, render.framebuffer.height as i32, 3, draw_color);
+            //    count_but+=1;
         }
         if window.is_key_pressed(Key::Right, KeyRepeat::No){
-            let mid_canvas = (render.framebuffer.height/2) as i32;
-                render.draw_horizontal_line(0, mid_canvas, render.framebuffer.width as i32, 3, draw_color);
-                count_but+=1;
+            //let mid_canvas = (render.framebuffer.height/2) as i32;
+              //  render.draw_horizontal_line(0, mid_canvas, render.framebuffer.width as i32, 3, draw_color);
+                //count_but+=1;
         }
         if window.is_key_pressed(Key::Left, KeyRepeat::No){
-                render.draw_perfect_diagonal_line(0, 0, render.framebuffer.width as i32, render.framebuffer.height as i32, 3, draw_color);
-                count_but+=1;
+                //render.draw_perfect_diagonal_line(0, 0, render.framebuffer.width as i32, render.framebuffer.height as i32, 3, draw_color);
+                //count_but+=1;
         }
         if window.is_key_pressed(Key::Down, KeyRepeat::No){
-                render.draw_perfect_diagonal_line(render.framebuffer.width as i32, 0, 0, render.framebuffer.height as i32, 3, draw_color);
-                count_but+=1;
+                //render.draw_perfect_diagonal_line(render.framebuffer.width as i32, 0, 0, render.framebuffer.height as i32, 3, draw_color);
+                //count_but+=1;
         }
         if window.is_key_pressed(Key::RightShift, KeyRepeat::No){
                 draw_color_sel += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,13 +78,13 @@ fn main() {
         if window.is_key_pressed(Key::S, KeyRepeat::No){
             let mid_width_canvas = (render.framebuffer.width/2) as i32;
             let mid_height_canvas = (render.framebuffer.height/2) as i32;
-            render.draw_rectangle_unfilled(
+            /*render.draw_rectangle_unfilled(
                 mid_width_canvas, 
                 mid_height_canvas, 
                 55, 
                 55, 
                 3, 
-                draw_color);
+                draw_color);*/
                 count_but+=1;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use crate::renderer::{color::{self, Color}, framebuffer::Framebuffer, render::Re
 fn main() {
     println!("Hello, world!");
     let buffer = Framebuffer::new(600, 600);
-    let mut render: Render = Render::new(buffer);
+    let mut render: Render = Render::new(buffer, Color::ZERO);
     let mut window = Window::new(
         "Test - ESC to exit",
         render.framebuffer.width as usize,
@@ -83,12 +83,27 @@ fn main() {
                 mid_height_canvas, 
                 55, 
                 55, 
-                3, 
+                0, 
                 draw_color);
                 count_but+=1;
+                /*if window.is_key_pressed(Key::S, KeyRepeat::No){
+                render.draw_rectangle_unfilled(
+                mid_width_canvas, 
+                mid_height_canvas, 
+                55, 
+                55, 
+                25, 
+                draw_color);
+                count_but+=1; }*/
+        }
+        if window.is_key_pressed(Key::C, KeyRepeat::No){
+            let mid_width_canvas = (render.framebuffer.width/2) as i32;
+            let mid_height_canvas = (render.framebuffer.height/2) as i32;
+            render.draw_circle(mid_width_canvas, mid_height_canvas, 500, draw_color);
+            count_but += 1;
         }
 
-            if window.is_key_pressed(Key::T, KeyRepeat::No){
+        if window.is_key_pressed(Key::T, KeyRepeat::No){
             let mid_width_canvas = (render.framebuffer.width/2) as i32;
             let mid_height_canvas = (render.framebuffer.height/2) as i32;
             render.draw_triangle(
@@ -97,6 +112,14 @@ fn main() {
                 mid_width_canvas+25, mid_height_canvas+25, 10, draw_color);
                 count_but+=1;
         }
+        
+        if window.is_key_pressed(Key::F, KeyRepeat::No){
+            let mid_width_canvas = render.framebuffer.width/2;
+            let mid_height_canvas = render.framebuffer.height/2;
+            render.fill(mid_width_canvas, mid_height_canvas, draw_color);
+            count_but+=1;
+        }
+
         // We unwrap here as we want this code to exit if it fails. Real applications may want to handle this in a different way
         window
             .update_with_buffer(&render.framebuffer.as_u32_buffer(), render.framebuffer.width as usize, render.framebuffer.height as usize)

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,15 @@ fn main() {
                 count_but+=1;
         }
 
+            if window.is_key_pressed(Key::T, KeyRepeat::No){
+            let mid_width_canvas = (render.framebuffer.width/2) as i32;
+            let mid_height_canvas = (render.framebuffer.height/2) as i32;
+            render.draw_triangle(
+                mid_width_canvas, mid_height_canvas-25,
+                mid_width_canvas-25, mid_height_canvas+25,
+                mid_width_canvas+25, mid_height_canvas+25, 10, draw_color);
+                count_but+=1;
+        }
         // We unwrap here as we want this code to exit if it fails. Real applications may want to handle this in a different way
         window
             .update_with_buffer(&render.framebuffer.as_u32_buffer(), render.framebuffer.width as usize, render.framebuffer.height as usize)

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,22 +50,22 @@ fn main() {
             count_but+=1;
         }
         if window.is_key_pressed(Key::Up, KeyRepeat::No){
-            let mid_canvas = render.framebuffer.width/2;    
-                render.draw_vertical_line(mid_canvas, 0, mid_canvas, render.framebuffer.height, 3, draw_color);
+            let mid_canvas= render.framebuffer.width as i32/2;    
+                render.draw_line(mid_canvas, 0, mid_canvas, render.framebuffer.height as i32, 3, draw_color);
                 count_but+=1;
         }
         if window.is_key_pressed(Key::Right, KeyRepeat::No){
-            let mid_canvas = render.framebuffer.height/2;
-            render.draw_horizontal_line(0, mid_canvas, render.framebuffer.width, mid_canvas, 3, draw_color);
-            count_but+=1;
+            let mid_canvas = render.framebuffer.height as i32/2;
+                render.draw_line(0, mid_canvas, render.framebuffer.width as i32, mid_canvas, 3, draw_color);
+                count_but+=1;
         }
         if window.is_key_pressed(Key::Left, KeyRepeat::No){
-                //render.draw_perfect_diagonal_line(0, 0, render.framebuffer.width as i32, render.framebuffer.height as i32, 3, draw_color);
-                //count_but+=1;
+                render.draw_line(0, 0, render.framebuffer.width as i32, render.framebuffer.height as i32, 3, draw_color);
+                count_but+=1;
         }
         if window.is_key_pressed(Key::Down, KeyRepeat::No){
-                //render.draw_perfect_diagonal_line(render.framebuffer.width as i32, 0, 0, render.framebuffer.height as i32, 3, draw_color);
-                //count_but+=1;
+                render.draw_line(render.framebuffer.width as i32, 0, 0, render.framebuffer.height as i32, 3, draw_color);
+                count_but+=1;
         }
         if window.is_key_pressed(Key::RightShift, KeyRepeat::No){
                 draw_color_sel += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,28 +78,20 @@ fn main() {
         if window.is_key_pressed(Key::S, KeyRepeat::No){
             let mid_width_canvas = (render.framebuffer.width/2) as i32;
             let mid_height_canvas = (render.framebuffer.height/2) as i32;
-            render.draw_rectangle_unfilled(
+            render.draw_rectangle(
                 mid_width_canvas, 
                 mid_height_canvas, 
                 55, 
-                55, 
-                0, 
+                55,
+                false,
+                3, 
                 draw_color);
                 count_but+=1;
-                /*if window.is_key_pressed(Key::S, KeyRepeat::No){
-                render.draw_rectangle_unfilled(
-                mid_width_canvas, 
-                mid_height_canvas, 
-                55, 
-                55, 
-                25, 
-                draw_color);
-                count_but+=1; }*/
         }
         if window.is_key_pressed(Key::C, KeyRepeat::No){
             let mid_width_canvas = (render.framebuffer.width/2) as i32;
             let mid_height_canvas = (render.framebuffer.height/2) as i32;
-            render.draw_circle(mid_width_canvas, mid_height_canvas, 500, draw_color);
+            render.draw_circle(mid_width_canvas, mid_height_canvas, 50, false, 3, draw_color);
             count_but += 1;
         }
 
@@ -109,7 +101,7 @@ fn main() {
             render.draw_triangle(
                 mid_width_canvas, mid_height_canvas-25,
                 mid_width_canvas-25, mid_height_canvas+25,
-                mid_width_canvas+25, mid_height_canvas+25, 10, draw_color);
+                mid_width_canvas+25, mid_height_canvas+25, false, 3, draw_color);
                 count_but+=1;
         }
         

--- a/src/renderer/Color.rs
+++ b/src/renderer/Color.rs
@@ -1,4 +1,4 @@
-#[derive (Debug, Clone, Copy)]
+#[derive (Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Color{
     pub r: u8,
     pub g: u8,
@@ -12,7 +12,7 @@ impl Color{
     pub const BLUE: Color  = Color { r: 0,   g: 0,   b: 255, a: 255 };
     pub const BLACK: Color = Color { r: 0,   g: 0,   b: 0,   a: 255 };
     pub const WHITE: Color = Color { r: 255, g: 255, b: 255, a: 255 };
-
+    pub const ZERO: Color  = Color { r:0,    g:0,    b:0,    a:0    };
     pub fn new(r:u8,g:u8,b:u8,a:u8) -> Self{
         Self {r,g,b,a}
     }

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -77,10 +77,10 @@ impl Render{
                 }
             }*/
         if x0 > x1 {
-            let (x0,x1) = (x1,x0);
-            let (y0,y1) = (y1,y0);
+            let x0 = x1; let x1 = x0;
+            let y0 = y1; let y1 = y0;
         }
-        let mut dx= (x1-x0) as i32;
+        let dx= (x1-x0) as i32;
         let mut dy= (y1-y0) as i32;
 
         let dir = {
@@ -94,13 +94,16 @@ impl Render{
         if dx != 0{
             let mut y = y0;
             let mut p = 2*dy - dx;
-            for i in dx..dx+1{
-                self.put_pixel(x0+(i as u32), y, color);
+            for i in -thickness..=thickness{
+            let cur_thickness:i32 = y as i32+i;
+            for j in -dx..dx+1{
+                self.put_pixel(x0+(j as u32), cur_thickness as u32, color);
                 if p >= 0{
                     y += dir as u32;
                     p = p - 2*dx;
                 }
-            p = p + 2*dy;
+                p = p + 2*dy;
+                }
             }
         }
     }

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -17,6 +17,7 @@ impl Render{
         for pixel in &mut self.framebuffer.pixels_buffer{
             *pixel = color;
         }
+        self.background_color = color;
     }
     /// Desenha um pixel (com bounds check)
     pub fn put_pixel(&mut self, x:u32, y:u32, color: Color){
@@ -125,5 +126,68 @@ impl Render{
     /// Acesso somente-leitura ao buffer
     pub fn buffer(&self) -> &[Color]{
         &self.framebuffer.pixels_buffer
+    }
+    pub fn fill(&mut self, x_ref_point: u32, y_ref_point: u32, color: Color){
+        let mut pix_vec:Vec<&mut Color> = Vec::new();
+        let paint_col = *self.return_pixel(x_ref_point, y_ref_point).expect("color");
+        let mut y = y_ref_point;
+        let height = self.framebuffer.height; let width = self.framebuffer.width;
+        while y < height{        
+            let mut x = x_ref_point;
+            while x < width{
+            let cur_address = self.return_pixel(x, y);
+            x+=1;
+            match cur_address{
+                Some(addr) => {
+                    if *addr == color || *addr != paint_col{
+                        if x >= width || y>=height{
+                            return;
+                        }
+                        let pix = *self.return_pixel(x_ref_point, y+1).expect("eh cor");
+                        if pix == color || pix != paint_col{
+                            if pix != paint_col{
+                                return;
+                            }
+                            return;
+                        }
+                        break;
+                    }
+                    println!("cor eh sla :{addr:?}");
+                    *addr = color;
+                }
+                None => {
+                    //PROBLEMÃO AQUI
+                    println!("achou nada !");
+                    return;
+                }
+            }
+        }
+            y+=1;
+        }
+    }
+
+
+    pub fn draw_circle(&mut self, cx:i32, cy:i32, r: i32, color: Color){
+        let mut x = 0;
+        let mut y = -r;
+        let mut p = -r;
+        while x < -y {
+            if p < 0{
+                y += 1;
+                p += 2+(x+y) + 1;
+            } else {
+                p += 2*x + 1;
+            }
+            self.put_pixel((cx+x) as u32, (cy+y) as u32, color);
+            self.put_pixel((cx-x) as u32, (cy+y) as u32, color);
+            self.put_pixel((cx+x) as u32, (cy-y) as u32, color);
+            self.put_pixel((cx-x) as u32, (cy-y) as u32, color);
+            self.put_pixel((cx+x) as u32, (cy+y) as u32, color);
+            self.put_pixel((cx+x) as u32, (cy-y) as u32, color);
+            self.put_pixel((cx-x) as u32, (cy+y) as u32, color);
+            self.put_pixel((cx-x) as u32, (cy-y) as u32, color);
+
+            x += 1;
+        }
     }
 }

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -128,41 +128,25 @@ impl Render{
         &self.framebuffer.pixels_buffer
     }
     pub fn fill(&mut self, x_ref_point: u32, y_ref_point: u32, color: Color){
-        let mut pix_vec:Vec<&mut Color> = Vec::new();
-        let paint_col = *self.return_pixel(x_ref_point, y_ref_point).expect("color");
-        let mut y = y_ref_point;
-        let height = self.framebuffer.height; let width = self.framebuffer.width;
-        while y < height{        
-            let mut x = x_ref_point;
-            while x < width{
-            let cur_address = self.return_pixel(x, y);
-            x+=1;
-            match cur_address{
-                Some(addr) => {
-                    if *addr == color || *addr != paint_col{
-                        if x >= width || y>=height{
-                            return;
-                        }
-                        let pix = *self.return_pixel(x_ref_point, y+1).expect("eh cor");
-                        if pix == color || pix != paint_col{
-                            if pix != paint_col{
-                                return;
-                            }
-                            return;
-                        }
-                        break;
-                    }
-                    println!("cor eh sla :{addr:?}");
-                    *addr = color;
-                }
-                None => {
-                    //PROBLEMÃO AQUI
-                    println!("achou nada !");
-                    return;
-                }
-            }
-        }
-            y+=1;
+        let paint_col = *self.return_pixel(x_ref_point, y_ref_point).unwrap();
+        if paint_col == color { return; }
+
+        let mut stack = Vec::new();
+        stack.push((x_ref_point as i32, y_ref_point as i32));
+
+        while let Some((x, y)) = stack.pop() {
+        if x < 0 || y < 0 { continue; }
+        if x >= self.framebuffer.width as i32 || y >= self.framebuffer.height as i32 { continue; }
+
+        let pixel = self.return_pixel(x as u32, y as u32).unwrap();
+        if *pixel != paint_col { continue; }
+
+        *pixel = color;
+
+        stack.push((x + 1, y));
+        stack.push((x - 1, y));
+        stack.push((x, y + 1));
+        stack.push((x, y - 1));
         }
     }
 

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -79,17 +79,31 @@ impl Render{
     }
 
 
-//  pub fn draw_rectangle_as_filled(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, thickness:i32, outline_color:Color, inline_color::Color){}
+  pub fn draw_rectangle_as_filled(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, thickness:i32, outline_color:Color, inline_color:Color){
+
+        //rightside
+        let x_coordinate_right_side = x_ref_point+width; //355
+        //leftside
+        let x_coordinate_left_side = x_ref_point-width; //245
+        //upline
+        let y_coordinate_up_side = y_ref_point+height;
+        //downline
+        let y_coordinate_down_side = y_ref_point-height;
+
+        self.draw_line(x_coordinate_right_side, y_coordinate_down_side - thickness, x_coordinate_right_side, y_coordinate_up_side + thickness, thickness, outline_color);
+        self.draw_line(x_coordinate_left_side,y_coordinate_down_side - thickness, x_coordinate_left_side, y_coordinate_up_side + thickness,thickness,outline_color);
+        self.draw_line(x_coordinate_left_side - thickness, y_coordinate_down_side, x_coordinate_right_side + thickness, y_coordinate_down_side, thickness, outline_color);
+        self.draw_line(x_coordinate_left_side - thickness, y_coordinate_up_side, x_coordinate_right_side + thickness, y_coordinate_up_side, thickness, outline_color);
+        
+  }
   pub fn draw_triangle(&mut self, 
     x_ref_vertex1:i32, y_ref_vertex1:i32,
     x_ref_vertex2:i32, y_ref_vertex2:i32, 
     x_ref_vertex3:i32, y_ref_vertex3:i32, thickness: i32, color:Color){
+        //implementar um fix para desenhar nas bordas usando um circulo cheio
         self.draw_line(x_ref_vertex1, y_ref_vertex1, x_ref_vertex2, y_ref_vertex2, thickness, color);
         self.draw_line(x_ref_vertex1, y_ref_vertex1, x_ref_vertex3, y_ref_vertex3, thickness, color);
         self.draw_line(x_ref_vertex2, y_ref_vertex2, x_ref_vertex3, y_ref_vertex3, thickness, color);
-        self.draw_line(x_ref_vertex2, y_ref_vertex2, x_ref_vertex1, y_ref_vertex1, thickness, color);
-        self.draw_line(x_ref_vertex3, y_ref_vertex3, x_ref_vertex1, y_ref_vertex1, thickness, color);
-        self.draw_line(x_ref_vertex3, y_ref_vertex3, x_ref_vertex2, y_ref_vertex2, thickness, color);
     }    
     /// Acesso somente-leitura ao buffer
     pub fn buffer(&self) -> &[Color]{

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -57,7 +57,7 @@ impl Render{
         }
     }
 
-  /*   pub fn draw_rectangle_unfilled(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, thickness:i32, color:Color){
+     pub fn draw_rectangle_unfilled(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, thickness:i32, color:Color){
         //x_start and x_end indicate the width of the rectangle and y_pos where those lines will be drawn
         //although it is possible that is nescesserary to indicate a reference point for the shape
         //as the shape shall be drawn from this point and may dictate the height and width of the shape.
@@ -71,12 +71,13 @@ impl Render{
         let y_coordinate_up_side = y_ref_point+height;
         //downline
         let y_coordinate_down_side = y_ref_point-height;
-        self.draw_vertical_line (x_coordinate_right_side,y_coordinate_down_side - thickness,y_coordinate_up_side + thickness,thickness,color);
-        self.draw_vertical_line (x_coordinate_left_side,y_coordinate_down_side - thickness,y_coordinate_up_side + thickness,thickness,color);
-        self.draw_horizontal_line(x_coordinate_left_side - thickness, y_coordinate_down_side, x_coordinate_right_side + thickness, thickness, color);
-        self.draw_horizontal_line(x_coordinate_left_side - thickness, y_coordinate_up_side, x_coordinate_right_side + thickness, thickness, color);
+        //self.draw_line(x0, y0, x1, y1, thickness, color);
+        self.draw_line(x_coordinate_right_side, y_coordinate_down_side - thickness, x_coordinate_right_side, y_coordinate_up_side + thickness, thickness, color);
+        self.draw_line(x_coordinate_left_side,y_coordinate_down_side - thickness, x_coordinate_left_side, y_coordinate_up_side + thickness,thickness,color);
+        self.draw_line(x_coordinate_left_side - thickness, y_coordinate_down_side, x_coordinate_right_side + thickness, y_coordinate_down_side, thickness, color);
+        self.draw_line(x_coordinate_left_side - thickness, y_coordinate_up_side, x_coordinate_right_side + thickness, y_coordinate_up_side, thickness, color);
     }
-*/
+
 
 //  pub fn draw_rectangle_as_filled(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, thickness:i32, outline_color:Color, inline_color::Color){}
 //  pub fn draw_triangle(&mut self, x_ref_point: i32, y_ref_point: i32, vertex1:i32, vertex1:i32, vertex3:i32, color:Color){}    

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -27,8 +27,9 @@ impl Render{
         let index = (y*self.framebuffer.width + x) as usize;
         self.framebuffer.pixels_buffer[index] = color;
     }
-    pub fn draw_line(&mut self, x0:u32, y0:u32, x1:u32,y1:u32){
+    pub fn draw_line(&mut self, x0:u32, y0:u32, x1:u32,y1:u32, thickness:i32, color: Color){
         //draws !
+
     }
 
     pub fn draw_vertical_line(&mut self, x0:u32, y0:u32, x1:u32, y1:u32,thickness:i32, color: Color){
@@ -75,7 +76,33 @@ impl Render{
                     }
                 }
             }*/
-    
+        if x0 > x1 {
+            let (x0,x1) = (x1,x0);
+            let (y0,y1) = (y1,y0);
+        }
+        let mut dx= (x1-x0) as i32;
+        let mut dy= (y1-y0) as i32;
+
+        let dir = {
+            if dy < 0{
+                -1
+            } else {
+                1
+            }
+        };
+        dy *= dir;
+        if dx != 0{
+            let mut y = y0;
+            let mut p = 2*dy - dx;
+            for i in dx..dx+1{
+                self.put_pixel(x0+(i as u32), y, color);
+                if p >= 0{
+                    y += dir as u32;
+                    p = p - 2*dx;
+                }
+            p = p + 2*dy;
+            }
+        }
     }
     pub fn draw_perfect_diagonal_line(&mut self, x_start:i32, y_start:i32, x_end:i32, y_end:i32, thickness:i32, color: Color){
         for i in -thickness..=thickness{

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -80,7 +80,17 @@ impl Render{
 
 
 //  pub fn draw_rectangle_as_filled(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, thickness:i32, outline_color:Color, inline_color::Color){}
-//  pub fn draw_triangle(&mut self, x_ref_point: i32, y_ref_point: i32, vertex1:i32, vertex1:i32, vertex3:i32, color:Color){}    
+  pub fn draw_triangle(&mut self, 
+    x_ref_vertex1:i32, y_ref_vertex1:i32,
+    x_ref_vertex2:i32, y_ref_vertex2:i32, 
+    x_ref_vertex3:i32, y_ref_vertex3:i32, thickness: i32, color:Color){
+        self.draw_line(x_ref_vertex1, y_ref_vertex1, x_ref_vertex2, y_ref_vertex2, thickness, color);
+        self.draw_line(x_ref_vertex1, y_ref_vertex1, x_ref_vertex3, y_ref_vertex3, thickness, color);
+        self.draw_line(x_ref_vertex2, y_ref_vertex2, x_ref_vertex3, y_ref_vertex3, thickness, color);
+        self.draw_line(x_ref_vertex2, y_ref_vertex2, x_ref_vertex1, y_ref_vertex1, thickness, color);
+        self.draw_line(x_ref_vertex3, y_ref_vertex3, x_ref_vertex1, y_ref_vertex1, thickness, color);
+        self.draw_line(x_ref_vertex3, y_ref_vertex3, x_ref_vertex2, y_ref_vertex2, thickness, color);
+    }    
     /// Acesso somente-leitura ao buffer
     pub fn buffer(&self) -> &[Color]{
         &self.framebuffer.pixels_buffer

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -27,8 +27,11 @@ impl Render{
         let index = (y*self.framebuffer.width + x) as usize;
         self.framebuffer.pixels_buffer[index] = color;
     }
+    pub fn draw_line(&mut self, x0:u32, y0:u32, x1:u32,y1:u32){
+        //draws !
+    }
 
-    pub fn draw_vertical_line(&mut self, x: i32, y_start:i32, y_end:i32, thickness:i32, color: Color){
+    pub fn draw_vertical_line(&mut self, x0:u32, y0:u32, x1:u32, y1:u32,thickness:i32, color: Color){
         /*for i in -thickness..=thickness{
                 let mut y:i32 = y_start;
                 if y_start < y_end{
@@ -51,7 +54,7 @@ impl Render{
         }*/
         
     }
-    pub fn draw_horizontal_line(&mut self, x_start:i32, y:i32, x_end:i32, thickness:i32, color: Color){
+    pub fn draw_horizontal_line(&mut self, x0:u32, y0:u32, x1:u32, y1:u32,thickness:i32, color: Color){
         /*for i in -thickness..=thickness{
                 let mut x = x_start as i32;
                 if x_start < x_end{
@@ -72,6 +75,7 @@ impl Render{
                     }
                 }
             }*/
+    
     }
     pub fn draw_perfect_diagonal_line(&mut self, x_start:i32, y_start:i32, x_end:i32, y_end:i32, thickness:i32, color: Color){
         for i in -thickness..=thickness{
@@ -132,7 +136,7 @@ impl Render{
                 }
             }
     }
-    pub fn draw_rectangle_unfilled(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, thickness:i32, color:Color){
+  /*   pub fn draw_rectangle_unfilled(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, thickness:i32, color:Color){
         //x_start and x_end indicate the width of the rectangle and y_pos where those lines will be drawn
         //although it is possible that is nescesserary to indicate a reference point for the shape
         //as the shape shall be drawn from this point and may dictate the height and width of the shape.
@@ -151,6 +155,8 @@ impl Render{
         self.draw_horizontal_line(x_coordinate_left_side - thickness, y_coordinate_down_side, x_coordinate_right_side + thickness, thickness, color);
         self.draw_horizontal_line(x_coordinate_left_side - thickness, y_coordinate_up_side, x_coordinate_right_side + thickness, thickness, color);
     }
+*/
+
 //  pub fn draw_rectangle_as_filled(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, thickness:i32, outline_color:Color, inline_color::Color){}
 //  pub fn draw_triangle(&mut self, x_ref_point: i32, y_ref_point: i32, vertex1:i32, vertex2:i32, vertex3:i32, color:Color){}    
     /// Acesso somente-leitura ao buffer

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -53,29 +53,38 @@ impl Render{
                 }
             }
         }*/
-        
+        if y0 > y1 {
+            let x0 = x1; let x1 = x0;
+            let y0 = y1; let y1 = y0;
+        }
+        let mut dx= (x1-x0) as i32;
+        let dy= (y1-y0) as i32;
+
+        let dir = {
+            if dy < 0{
+                -1
+            } else {
+                1
+            }
+        };
+        dx *= dir;
+        if dy != 0{
+            let mut x = x0;
+            let mut p = 2*dx - dy;
+            for i in -thickness..=thickness{
+            let cur_thickness:i32 = x as i32+i;
+            for j in -dy..dy+1{
+                self.put_pixel(cur_thickness as u32, j as u32, color);
+                if p >= 0{
+                    x += dir as u32;
+                    p = p - 2*dx;
+                }
+                p = p + 2*dy;
+                }
+            }
+        }
     }
     pub fn draw_horizontal_line(&mut self, x0:u32, y0:u32, x1:u32, y1:u32,thickness:i32, color: Color){
-        /*for i in -thickness..=thickness{
-                let mut x = x_start as i32;
-                if x_start < x_end{
-                //less than size
-                    while x <= x_end{
-                        //implict clamp
-                        let cur_thickness = (y+i) as u32;
-                        self.put_pixel(x as u32, cur_thickness, color);
-                        x+=1;
-                    }
-                } else {
-                //more than size
-                    while x >= x_end{
-                        //implict clamp
-                        let cur_thickness = (y+i) as u32;
-                        self.put_pixel(x as u32, cur_thickness, color);
-                        x-=1;
-                    }
-                }
-            }*/
         if x0 > x1 {
             let x0 = x1; let x1 = x0;
             let y0 = y1; let y1 = y0;

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -27,154 +27,36 @@ impl Render{
         let index = (y*self.framebuffer.width + x) as usize;
         self.framebuffer.pixels_buffer[index] = color;
     }
-    pub fn draw_line(&mut self, x0:u32, y0:u32, x1:u32,y1:u32, thickness:i32, color: Color){
-        //draws !
+    pub fn draw_line(&mut self, x0:i32, y0:i32, x1:i32,y1:i32, thickness:i32, color: Color){
+        let dx:i32 = i32::abs(x1 - x0);
+        let dy:i32 = i32::abs(y1 - y0);
+        let sx:i32 = { if x0 < x1 { 1 } else { -1 } };
+        let sy:i32 = { if y0 < y1 { 1 } else { -1 } };
 
-    }
+        let mut error:i32 = (if dx > dy  { dx } else { -dy }) / 2 ;
 
-    pub fn draw_vertical_line(&mut self, x0:u32, y0:u32, x1:u32, y1:u32,thickness:i32, color: Color){
-        /*for i in -thickness..=thickness{
-                let mut y:i32 = y_start;
-                if y_start < y_end{
-                //less than size
-                while y <= y_end{
-                    //implict clamp
-                    let cur_thickness = (x+i) as u32;
-                    self.put_pixel(cur_thickness, y as u32, color);
-                    y+=1;
+        let mut x = x0;
+        let mut y = y0;
+            loop {
+            // desenha com thickness discreto
+            if dx >= dy {
+                for o in -thickness..=thickness {
+                    self.put_pixel(x as u32, (y + o) as u32, color);
                 }
             } else {
-                //more than size
-                    while y >= y_end{
-                    //implict clamp
-                    let cur_thickness = (x+i) as u32;
-                    self.put_pixel(cur_thickness, y as u32, color);
-                    y-=1;
+                for o in -thickness..=thickness {
+                    self.put_pixel((x + o) as u32, y as u32, color);
                 }
             }
-        }*/
-        if y0 > y1 {
-            let x0 = x1; let x1 = x0;
-            let y0 = y1; let y1 = y0;
-        }
-        let mut dx= (x1-x0) as i32;
-        let dy= (y1-y0) as i32;
 
-        let dir = {
-            if dy < 0{
-                -1
-            } else {
-                1
-            }
-        };
-        dx *= dir;
-        if dy != 0{
-            let mut x = x0;
-            let mut p = 2*dx - dy;
-            for i in -thickness..=thickness{
-            let cur_thickness:i32 = x as i32+i;
-            for j in -dy..dy+1{
-                self.put_pixel(cur_thickness as u32, j as u32, color);
-                if p >= 0{
-                    x += dir as u32;
-                    p = p - 2*dx;
-                }
-                p = p + 2*dy;
-                }
-            }
-        }
-    }
-    pub fn draw_horizontal_line(&mut self, x0:u32, y0:u32, x1:u32, y1:u32,thickness:i32, color: Color){
-        if x0 > x1 {
-            let x0 = x1; let x1 = x0;
-            let y0 = y1; let y1 = y0;
-        }
-        let dx= (x1-x0) as i32;
-        let mut dy= (y1-y0) as i32;
+            if x == x1 && y == y1 { break; }
 
-        let dir = {
-            if dy < 0{
-                -1
-            } else {
-                1
-            }
-        };
-        dy *= dir;
-        if dx != 0{
-            let mut y = y0;
-            let mut p = 2*dy - dx;
-            for i in -thickness..=thickness{
-            let cur_thickness:i32 = y as i32+i;
-            for j in -dx..dx+1{
-                self.put_pixel(x0+(j as u32), cur_thickness as u32, color);
-                if p >= 0{
-                    y += dir as u32;
-                    p = p - 2*dx;
-                }
-                p = p + 2*dy;
-                }
-            }
+            let e2 = 2 * error;
+            if e2 > -dy { error -= dy; x += sx; }
+            if e2 <  dx { error += dx; y += sy; }
         }
     }
-    pub fn draw_perfect_diagonal_line(&mut self, x_start:i32, y_start:i32, x_end:i32, y_end:i32, thickness:i32, color: Color){
-        for i in -thickness..=thickness{
-                let mut x = x_start as i32;
-                let mut y = y_start as i32;
-                if x_start < x_end && y_start < y_end{
-                    //less than size
-                    while x <= x_end &&  y <= y_end{
-                        //implict clamp
-                        let cur_thickness_y = (y+i) as u32;
-                        let cur_thickness_x = (x+i) as u32;
-                        self.put_pixel(x as u32, cur_thickness_y, color);
-                        self.put_pixel(y as u32, cur_thickness_x, color);
-                        x+=1;
-                        y+=1;
-                        }
-                println!("veio pro lado menor !")
-                } 
-                if  x_start > x_end && y_start > y_end{
-                    //more than size
-                    while x >= x_end &&  y >= y_end{
-                        //implict clamp
-                        let cur_thickness_y = (y+i) as u32;
-                        let cur_thickness_x = (x+i) as u32;
-                        self.put_pixel(x as u32, cur_thickness_y, color);
-                        self.put_pixel(y as u32, cur_thickness_x, color);
-                        x-=1;
-                        y-=1;
-                        }
-                    println!("veio pro lado maior !");
-                } else {
-                    if x_start >= x_end{
-                        // x axis is dominant
-                        while x >= x_end &&  y <= y_end{
-                        //implict clamp
-                        let cur_thickness_y = (y+i) as u32;
-                        let cur_thickness_x = (x+i) as u32;
-                        self.put_pixel(x as u32, cur_thickness_y, color);
-                        self.put_pixel(y as u32, cur_thickness_x, color);
-                        x-=1;
-                        y+=1;
-                        }
-                    println!("veio pro lado x eh maior !");
-                    }
-                    if y_start >= y_end{
-                        // y axis is dominant
-                        while x <= x_end &&  y >= y_end{
-                        //implict clamp
-                        let cur_thickness_y = (y+i) as u32;
-                        let cur_thickness_x = (x+i) as u32;
-                        self.put_pixel(x as u32, cur_thickness_y, color);
-                        self.put_pixel(y as u32, cur_thickness_x, color);
-                        x+=1;
-                        y-=1;
-                        }
-                        println!("veio pro lado y eh maior !");
-                    }
-                }
-            }
-    }
+
   /*   pub fn draw_rectangle_unfilled(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, thickness:i32, color:Color){
         //x_start and x_end indicate the width of the rectangle and y_pos where those lines will be drawn
         //although it is possible that is nescesserary to indicate a reference point for the shape
@@ -197,7 +79,7 @@ impl Render{
 */
 
 //  pub fn draw_rectangle_as_filled(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, thickness:i32, outline_color:Color, inline_color::Color){}
-//  pub fn draw_triangle(&mut self, x_ref_point: i32, y_ref_point: i32, vertex1:i32, vertex2:i32, vertex3:i32, color:Color){}    
+//  pub fn draw_triangle(&mut self, x_ref_point: i32, y_ref_point: i32, vertex1:i32, vertex1:i32, vertex3:i32, color:Color){}    
     /// Acesso somente-leitura ao buffer
     pub fn buffer(&self) -> &[Color]{
         &self.framebuffer.pixels_buffer

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -70,7 +70,7 @@ impl Render{
         }
     }
 
-     pub fn draw_rectangle_unfilled(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, thickness:i32, color:Color){
+     pub fn draw_rectangle(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, is_filled:bool, thickness:i32, color:Color){
         //x_start and x_end indicate the width of the rectangle and y_pos where those lines will be drawn
         //although it is possible that is nescesserary to indicate a reference point for the shape
         //as the shape shall be drawn from this point and may dictate the height and width of the shape.
@@ -89,39 +89,26 @@ impl Render{
         self.draw_line(x_coordinate_left_side,y_coordinate_down_side - thickness, x_coordinate_left_side, y_coordinate_up_side + thickness,thickness,color);
         self.draw_line(x_coordinate_left_side - thickness, y_coordinate_down_side, x_coordinate_right_side + thickness, y_coordinate_down_side, thickness, color);
         self.draw_line(x_coordinate_left_side - thickness, y_coordinate_up_side, x_coordinate_right_side + thickness, y_coordinate_up_side, thickness, color);
+        
+        if is_filled == true{
+            self.fill(x_ref_point as u32, y_ref_point as u32, color);
+        }
     }
 
-
-  pub fn draw_rectangle_as_filled(&mut self, x_ref_point: i32, y_ref_point: i32, width:i32, height:i32, thickness:i32, outline_color:Color, inline_color:Color){
-
-        //rightside
-        let x_coordinate_right_side = x_ref_point+width; //355
-        //leftside
-        let x_coordinate_left_side = x_ref_point-width; //245
-        //upline
-        let y_coordinate_up_side = y_ref_point+height;
-        //downline
-        let y_coordinate_down_side = y_ref_point-height;
-
-        self.draw_line(x_coordinate_right_side, y_coordinate_down_side - thickness, x_coordinate_right_side, y_coordinate_up_side + thickness, thickness, outline_color);
-        self.draw_line(x_coordinate_left_side,y_coordinate_down_side - thickness, x_coordinate_left_side, y_coordinate_up_side + thickness,thickness,outline_color);
-        self.draw_line(x_coordinate_left_side - thickness, y_coordinate_down_side, x_coordinate_right_side + thickness, y_coordinate_down_side, thickness, outline_color);
-        self.draw_line(x_coordinate_left_side - thickness, y_coordinate_up_side, x_coordinate_right_side + thickness, y_coordinate_up_side, thickness, outline_color);
-
-        /*for mut i in 0..self.framebuffer.pixels_buffer.len()-1{
-            let curr_color = self.framebuffer.pixels_buffer[i];
-            
-            
-        }        */
-  }
   pub fn draw_triangle(&mut self, 
     x_ref_vertex1:i32, y_ref_vertex1:i32,
     x_ref_vertex2:i32, y_ref_vertex2:i32, 
-    x_ref_vertex3:i32, y_ref_vertex3:i32, thickness: i32, color:Color){
+    x_ref_vertex3:i32, y_ref_vertex3:i32, is_filled:bool, thickness: i32, color:Color){
         //implementar um fix para desenhar nas bordas usando um circulo cheio
         self.draw_line(x_ref_vertex1, y_ref_vertex1, x_ref_vertex2, y_ref_vertex2, thickness, color);
         self.draw_line(x_ref_vertex1, y_ref_vertex1, x_ref_vertex3, y_ref_vertex3, thickness, color);
         self.draw_line(x_ref_vertex2, y_ref_vertex2, x_ref_vertex3, y_ref_vertex3, thickness, color);
+
+        if is_filled == true{
+            let center_x = (x_ref_vertex1 + x_ref_vertex2 + x_ref_vertex3) / 3;
+            let center_y = (y_ref_vertex1 + y_ref_vertex2 + y_ref_vertex3) / 3;
+            self.fill(center_x as u32, center_y as u32, color);
+        }
     }    
     /// Acesso somente-leitura ao buffer
     pub fn buffer(&self) -> &[Color]{
@@ -150,28 +137,30 @@ impl Render{
         }
     }
 
-
-    pub fn draw_circle(&mut self, cx:i32, cy:i32, r: i32, color: Color){
+    pub fn draw_circle(&mut self, cx:i32, cy:i32, r: i32, is_filled:bool, thickness: i32, color: Color){
         let mut x = 0;
         let mut y = -r;
         let mut p = -r;
-        while x < -y {
-            if p < 0{
-                y += 1;
-                p += 2+(x+y) + 1;
-            } else {
-                p += 2*x + 1;
-            }
-            self.put_pixel((cx+x) as u32, (cy+y) as u32, color);
-            self.put_pixel((cx-x) as u32, (cy+y) as u32, color);
-            self.put_pixel((cx+x) as u32, (cy-y) as u32, color);
-            self.put_pixel((cx-x) as u32, (cy-y) as u32, color);
-            self.put_pixel((cx+x) as u32, (cy+y) as u32, color);
-            self.put_pixel((cx+x) as u32, (cy-y) as u32, color);
-            self.put_pixel((cx-x) as u32, (cy+y) as u32, color);
-            self.put_pixel((cx-x) as u32, (cy-y) as u32, color);
+            while x < -y {  
+                if p > 0{
+                    y += 1;
+                    p += 2*(x+y) + 1;
+                } else {
+                    p += 2*x + 1;
+                }
+                self.put_pixel((cx+x) as u32, (cy+y) as u32, color);
+                self.put_pixel((cx-x) as u32, (cy+y) as u32, color);
+                self.put_pixel((cx+x) as u32, (cy-y) as u32, color);
+                self.put_pixel((cx-x) as u32, (cy-y) as u32, color);
+                self.put_pixel((cx+y) as u32, (cy+x) as u32, color);
+                self.put_pixel((cx+y) as u32, (cy-x) as u32, color);
+                self.put_pixel((cx-y) as u32, (cy+x) as u32, color);
+                self.put_pixel((cx-y) as u32, (cy-x) as u32, color);
 
-            x += 1;
+                x += 1;
+            }
+        if is_filled == true{
+            self.fill(cx as u32, cy as u32, color);
         }
     }
 }

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -3,13 +3,14 @@ use crate::renderer::{color::Color, framebuffer::{*}};
 #[derive (Debug)]
 pub struct Render{
     pub framebuffer : Framebuffer,
+    pub background_color : Color,
     //window??
 }
 
-impl Render{  
+impl Render{
     /// Cria o renderer com um framebuffer inicial
-    pub fn new(framebuffer: Framebuffer) -> Render{
-        return Self { framebuffer };
+    pub fn new(framebuffer: Framebuffer, background_color:Color) -> Render{
+        return Self { framebuffer, background_color};
     }
     /// Limpa o framebuffer com uma cor
     pub fn clear(&mut self, color: Color){
@@ -28,12 +29,12 @@ impl Render{
         self.framebuffer.pixels_buffer[index] = color;
     }
 
-    pub fn return_pixel(&mut self, x:u32, y:u32) -> Option<&Color>{
+    pub fn return_pixel(&mut self, x:u32, y:u32) -> Option<&mut Color>{
             if x>= self.framebuffer.width || y>= self.framebuffer.height {
             return None;
         } else {
             let index = (y*self.framebuffer.width + x) as usize;
-            let col_ref = &self.framebuffer.pixels_buffer[index];
+            let col_ref = &mut self.framebuffer.pixels_buffer[index];
             return Some(col_ref);
         }
     }

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -99,11 +99,20 @@ impl Render{
     x_ref_vertex1:i32, y_ref_vertex1:i32,
     x_ref_vertex2:i32, y_ref_vertex2:i32, 
     x_ref_vertex3:i32, y_ref_vertex3:i32, is_filled:bool, thickness: i32, color:Color){
+        
+        let r = thickness*2 / 2;
+
+        self.draw_circle(x_ref_vertex1, y_ref_vertex1+3, r, true, 0, color);
+        self.draw_circle(x_ref_vertex2+1, y_ref_vertex2, r, true, 0, color);
+        self.draw_circle(x_ref_vertex3-1, y_ref_vertex3, r, true, 0, color);
+
+        
         //implementar um fix para desenhar nas bordas usando um circulo cheio
         self.draw_line(x_ref_vertex1, y_ref_vertex1, x_ref_vertex2, y_ref_vertex2, thickness, color);
         self.draw_line(x_ref_vertex1, y_ref_vertex1, x_ref_vertex3, y_ref_vertex3, thickness, color);
         self.draw_line(x_ref_vertex2, y_ref_vertex2, x_ref_vertex3, y_ref_vertex3, thickness, color);
 
+        
         if is_filled == true{
             let center_x = (x_ref_vertex1 + x_ref_vertex2 + x_ref_vertex3) / 3;
             let center_y = (y_ref_vertex1 + y_ref_vertex2 + y_ref_vertex3) / 3;
@@ -160,7 +169,8 @@ impl Render{
                 x += 1;
             }
         if is_filled == true{
-            self.fill(cx as u32, cy as u32, color);
+
+                self.fill(cx as u32, cy as u32, color);
         }
     }
 }

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -27,16 +27,9 @@ impl Render{
         let index = (y*self.framebuffer.width + x) as usize;
         self.framebuffer.pixels_buffer[index] = color;
     }
-    //Generalized draw, should unify draw vertical and horizontal lines along the center of the canvas
-    /*pub fn draw_line(&mut self, mut x0:i32, x1:i32, mut y0:i32, y1:i32, size:i32, color: Color){
-        //aqui deveria receber o eixo de desenho, seja x ou  ou os dois
-        //mas e se depois eu quiser reutilizar para o mouse ?
-        //vai ter que passar os dois eixos
-        //x1 e y1 são limites no meu código
-        
-    }*/
+
     pub fn draw_vertical_line(&mut self, x: i32, y_start:i32, y_end:i32, thickness:i32, color: Color){
-        for i in -thickness..=thickness{
+        /*for i in -thickness..=thickness{
                 let mut y:i32 = y_start;
                 if y_start < y_end{
                 //less than size
@@ -55,10 +48,11 @@ impl Render{
                     y-=1;
                 }
             }
-        }
+        }*/
+        
     }
     pub fn draw_horizontal_line(&mut self, x_start:i32, y:i32, x_end:i32, thickness:i32, color: Color){
-        for i in -thickness..=thickness{
+        /*for i in -thickness..=thickness{
                 let mut x = x_start as i32;
                 if x_start < x_end{
                 //less than size
@@ -77,7 +71,7 @@ impl Render{
                         x-=1;
                     }
                 }
-            }
+            }*/
     }
     pub fn draw_perfect_diagonal_line(&mut self, x_start:i32, y_start:i32, x_end:i32, y_end:i32, thickness:i32, color: Color){
         for i in -thickness..=thickness{

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -27,6 +27,17 @@ impl Render{
         let index = (y*self.framebuffer.width + x) as usize;
         self.framebuffer.pixels_buffer[index] = color;
     }
+
+    pub fn return_pixel(&mut self, x:u32, y:u32) -> Option<&Color>{
+            if x>= self.framebuffer.width || y>= self.framebuffer.height {
+            return None;
+        } else {
+            let index = (y*self.framebuffer.width + x) as usize;
+            let col_ref = &self.framebuffer.pixels_buffer[index];
+            return Some(col_ref);
+        }
+    }
+
     pub fn draw_line(&mut self, x0:i32, y0:i32, x1:i32,y1:i32, thickness:i32, color: Color){
         let dx:i32 = i32::abs(x1 - x0);
         let dy:i32 = i32::abs(y1 - y0);
@@ -94,7 +105,12 @@ impl Render{
         self.draw_line(x_coordinate_left_side,y_coordinate_down_side - thickness, x_coordinate_left_side, y_coordinate_up_side + thickness,thickness,outline_color);
         self.draw_line(x_coordinate_left_side - thickness, y_coordinate_down_side, x_coordinate_right_side + thickness, y_coordinate_down_side, thickness, outline_color);
         self.draw_line(x_coordinate_left_side - thickness, y_coordinate_up_side, x_coordinate_right_side + thickness, y_coordinate_up_side, thickness, outline_color);
-        
+
+        /*for mut i in 0..self.framebuffer.pixels_buffer.len()-1{
+            let curr_color = self.framebuffer.pixels_buffer[i];
+            
+            
+        }        */
   }
   pub fn draw_triangle(&mut self, 
     x_ref_vertex1:i32, y_ref_vertex1:i32,


### PR DESCRIPTION
This PR concludes the integration of the Bresenham line drawing algorithm, fully replacing the previous line-drawing implementations. In addition to Bresenham-based line rendering, this iteration also includes:

1. Rectangle primitive (outline and filled)
2. Triangle primitive (with vertex join fixes for the outlines)
3. Circle primitive
4. Flood fill implementation

All features are functional and have been tested visually using the minifb renderer, as shown in the screenshots below. The current state of the code is stable and ready to be merged into the minifb-renderer branch.


<img width="375" height="395" alt="Captura de tela 2025-12-30 152129" src="https://github.com/user-attachments/assets/0ee55829-31f3-4fe8-8dae-1adde47b9241" />
<img width="375" height="395" alt="Captura de tela 2025-12-30 152413" src="https://github.com/user-attachments/assets/2bae2cd4-e5cc-42c3-95b5-a4d5d5fe1914" />
<img width="375" height="395" alt="Captura de tela 2025-12-30 152511" src="https://github.com/user-attachments/assets/833e99df-de2b-415a-9f9a-33b454c141af" />
<img width="375" height="395" alt="Captura de tela 2025-12-30 152527" src="https://github.com/user-attachments/assets/1b1aefec-0f91-4e33-a216-025515fc3098" />